### PR TITLE
Add BrewPage (free no-signup static/HTML hosting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 |20 | Framagit Pages | OSS Git hosting. | Unlimited projects. | https://framagit.org |
 |21 | Pagekite | Local tunnel hosting. | 1 site. | https://pagekite.net |
 |22 | OneClickLive | Paste HTML/JSX, get a live HTTPS URL in 3 seconds. Auto-wraps React without a build step. | No account required for first deploy. | https://oneclicklive.app |
+|23 | BrewPage | Instant hosting for HTML, Markdown, JSON, key-value data, files and multi-file static sites. REST API + MCP server (AI/agent-friendly). | Free, no signup, fast. | https://brewpage.app |
 
 ---
 


### PR DESCRIPTION
Adds **BrewPage** (https://brewpage.app) to the Static Site Hosting section.

BrewPage is a genuinely **free, no-signup** host for HTML, Markdown, JSON, key-value data, files, and multi-file static sites — publish instantly with no account required. It also ships a **REST API** and an **MCP server**, making it AI/agent-friendly for programmatic and LLM-driven publishing.

The new entry follows the exact table format of the surrounding rows in the section.