### PR TITLE
Add Nippy — share files, folders & AI-generated pages as a website

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 |22 | OneClickLive | Paste HTML/JSX, get a live HTTPS URL in 3 seconds. Auto-wraps React without a build step. | No account required for first deploy. | https://oneclicklive.app |
 |23 | BrewPage | Instant hosting for HTML, Markdown, JSON, key-value data, files and multi-file static sites. REST API + MCP server (AI/agent-friendly). | Free, no signup, fast. | https://brewpage.app |
 |24 | Snapy | Drop a file, an HTML page, or a zipped static site (React/Next export) and get a clean public link. Single files and AI-generated pages too. | No signup, 100 MB/file, links persist by default. | https://snapy.host |
+|25 | Nippy | Drag in files, photos, or a whole folder and get a permanent public link — static sites or any files, no build step. Handy for sharing AI-generated pages and docs. | 1 site, 25 MB storage, no card. | https://nippy.host |
 
 ---
 


### PR DESCRIPTION
Adds **Nippy** (https://nippy.host) to the Static Site Hosting section.

Nippy turns anything into a website: drag in files, photos, or a whole folder and get a permanent public link anyone can open — static sites or any files, no build step. It's handy for sharing AI-generated pages and exported docs (e.g. Claude/ChatGPT artifacts) without wiring up a host.

**Genuine free tier** with clear limits: 1 live site, 25 MB storage, no credit card required. (Publishing does ask for an email to verify the account — so not no-signup, but no card.)

The new entry follows the exact table format of the surrounding rows in the section. Happy to adjust the description, limits, or placement if you'd like.