### PR TITLE
Add harvis.dev to Static Site Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 |24 | Snapy | Drop a file, an HTML page, or a zipped static site (React/Next export) and get a clean public link. Single files and AI-generated pages too. | No signup, 100 MB/file, links persist by default. | https://snapy.host |
 |25 | Nippy | Drag in files, photos, or a whole folder and get a permanent public link — static sites or any files, no build step. Handy for sharing AI-generated pages and docs. | 1 site, 25 MB storage, no card. | https://nippy.host |
 |26 | host-html | API-first hosting site for static HTML pages, with password protection, analytics and other paid features. | 5 sites, 1 MB storage per site, no card. | https://host-html.com |
+|27 | harvis.dev | Zero-setup static hosting: run npx harvis or drag a folder in and get a live URL in seconds. CLI, drag-and-drop, HTTP API and MCP server for AI agents; built-in form handling. | Free for small sites, no signup for first deploy. | https://harvis.dev |
 
 ---
 


### PR DESCRIPTION
Adds harvis.dev as row 27 of the Static Site Hosting table.

harvis.dev is zero-setup static hosting: run `npx harvis` in any folder or drag it into the browser and get a live URL in about two seconds — no signup needed for the first deploy (you get a private claim link to take ownership later). It also has an HTTP API, a GitHub-Action-friendly CLI, and an MCP server so AI agents can deploy, plus built-in form handling. Free for small sites.

Disclosure: I built harvis.dev.